### PR TITLE
Use common mbed_net_if instead get_default_instance() call

### DIFF
--- a/net/include/net_common.h
+++ b/net/include/net_common.h
@@ -22,6 +22,8 @@ extern "C" {
 int convert_bsd_addr_to_mbed(SocketAddress * out, struct sockaddr * in);
 int convert_mbed_addr_to_bsd(struct sockaddr * out, const SocketAddress * in);
 
+NetworkInterface * get_mbed_net_if(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/src/BSDSocket.cpp
+++ b/net/src/BSDSocket.cpp
@@ -31,7 +31,7 @@ int BSDSocket::open(int family, int type, InternetSocket * socket)
             return -1;
         };
 
-        if (_socket->open(NetworkInterface::get_default_instance()) != NSAPI_ERROR_OK)
+        if (_socket->open(get_mbed_net_if()) != NSAPI_ERROR_OK)
         {
             close();
             tr_err("Open socket failed");

--- a/net/src/net_common.cpp
+++ b/net/src/net_common.cpp
@@ -1,6 +1,9 @@
 #include "net_common.h"
+#include <NetworkInterface.h>
 #include <stdlib.h>
 #include <string.h>
+
+static NetworkInterface * mbed_net_if = nullptr;
 
 int convert_bsd_addr_to_mbed(SocketAddress * out, struct sockaddr * in)
 {
@@ -53,4 +56,13 @@ int convert_mbed_addr_to_bsd(struct sockaddr * out, const SocketAddress * in)
     }
 
     return 0;
+}
+
+NetworkInterface * get_mbed_net_if()
+{
+    if (mbed_net_if == nullptr)
+    {
+        mbed_net_if = NetworkInterface::get_default_instance();
+    }
+    return mbed_net_if;
 }

--- a/net/src/net_common.cpp
+++ b/net/src/net_common.cpp
@@ -3,8 +3,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-static NetworkInterface * mbed_net_if = nullptr;
-
 int convert_bsd_addr_to_mbed(SocketAddress * out, struct sockaddr * in)
 {
     if (out == NULL || in == NULL)
@@ -60,9 +58,6 @@ int convert_mbed_addr_to_bsd(struct sockaddr * out, const SocketAddress * in)
 
 NetworkInterface * get_mbed_net_if()
 {
-    if (mbed_net_if == nullptr)
-    {
-        mbed_net_if = NetworkInterface::get_default_instance();
-    }
+    static NetworkInterface * mbed_net_if = NetworkInterface::get_default_instance();
     return mbed_net_if;
 }

--- a/net/src/net_dns.cpp
+++ b/net/src/net_dns.cpp
@@ -17,7 +17,7 @@ int mbed_getaddrinfo(const char * nodename, const char * servname, const struct 
         return EAI_SYSTEM;
     }
 
-    NetworkInterface * net = NetworkInterface::get_default_instance();
+    NetworkInterface * net = get_mbed_net_if();
     if (net == nullptr)
     {
         set_errno(ENETUNREACH);

--- a/net/src/net_if.cpp
+++ b/net/src/net_if.cpp
@@ -17,7 +17,7 @@ struct if_nameindex * mbed_if_nameindex(void)
     unsigned int if_counter        = 0;
     struct if_nameindex * net_list = NULL;
 
-    NetworkInterface * net_if = NetworkInterface::get_default_instance();
+    NetworkInterface * net_if = get_mbed_net_if();
     if (net_if == nullptr)
     {
         set_errno(ENOBUFS);
@@ -210,7 +210,7 @@ int mbed_getifaddrs(struct ifaddrs ** ifap)
 
     *ifap = NULL;
 
-    NetworkInterface * net_if = NetworkInterface::get_default_instance();
+    NetworkInterface * net_if = get_mbed_net_if();
     if (net_if == nullptr)
     {
         set_errno(ENETUNREACH);
@@ -630,7 +630,7 @@ static int mbed_get_if_flags(unsigned int * flags)
     SocketAddress netmask;
     NetworkInterface * net_if;
 
-    net_if = NetworkInterface::get_default_instance();
+    net_if = get_mbed_net_if();
     if (net_if == nullptr)
     {
         set_errno(ENOTTY);


### PR DESCRIPTION
Using NetworkInterface::get_default_instance() function causes setting default parameters for default interfaces for example WiFi interface set default credentials. To avoid overwriting application settings we need to call NetworkInterface::get_default_instance() only one time. 

Changset:
Set common mbed_net_if with getter function 
Change get_default_instance() to common mbed_net_if in BSDSocket, net_dns, net_if