### PR TITLE
Add IPV6_RECVPKTINFO

### DIFF
--- a/net/src/net_socket.cpp
+++ b/net/src/net_socket.cpp
@@ -89,7 +89,7 @@ static mbed_socket_option_t convert_socket_option(int level, int optname)
             return { NSAPI_SOCKET, NSAPI_ADD_MEMBERSHIP };
         case IPV6_DROP_MEMBERSHIP:
             return { NSAPI_SOCKET, NSAPI_DROP_MEMBERSHIP };
-        case IPV6_PKTINFO:
+        case IPV6_RECVPKTINFO:
             return { NSAPI_SOCKET, NSAPI_PKTINFO };
         default:
             tr_warning("Passing unknown IP6 option %d to socket", optname);

--- a/posix/include/sys/socket.h
+++ b/posix/include/sys/socket.h
@@ -439,6 +439,9 @@ struct in_pktinfo {
 	struct in_addr	ipi_addr;
 };
 
+// IPv6 recv packet info option
+#define IPV6_RECVPKTINFO 49
+
 // IPv6 packet info option
 #define IPV6_PKTINFO 50
 


### PR DESCRIPTION
Mbed-os POSIX socket implementation needs to support the IPV6_RECVPKTINFO socket option.
Add IPV6_RECVPKTINFO in socket.h
Change the IPV6_PKTINFO to IPV6_RECVPKTINFO in option converter.
IPV6_PKTINFO is used to set the default address, not to fill up control message strucutre